### PR TITLE
eredis_cluster_pool_worker crashes on query timeout

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %% -*- mode: erlang -*-
 {deps, [
-  {eredis, {git, "https://github.com/emqx/eredis", {tag, "1.2.8"}}},
+  {eredis, {git, "https://github.com/emqx/eredis", {tag, "1.2.9"}}},
   {poolboy, {git, "https://github.com/devinus/poolboy.git", {branch, "1.5.1"}}}
 ]}.
 {erl_opts, [warnings_as_errors,

--- a/src/eredis_cluster.appup.src
+++ b/src/eredis_cluster.appup.src
@@ -15,21 +15,24 @@
       {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_monitor, brutal_purge, soft_purge, []}
     ]},
-    {<<"0.6.[3-6]">>, [
+    {<<"0\\.6\\.[3-6]">>, [
       {load_module, eredis_cluster_sup, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_pool, brutal_purge, soft_purge, []},
-      {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []}
+      {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []},
+      {load_module, eredis_cluster_monitor, brutal_purge, soft_purge, []}
     ]},
     {"0.6.7", [
       {load_module, eredis_cluster_sup, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_pool, brutal_purge, soft_purge, []},
+      {load_module, eredis_cluster_monitor, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster, brutal_purge, soft_purge, []}
     ]},
-    {<<"0.7.[0-3]">>, [
+    {<<"0\\.7\\.[0-3]">>, [
       {load_module, eredis_cluster_pool, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_cluster_monitor, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []}
     ]},
     {<<".*">>, [
@@ -50,21 +53,24 @@
       {load_module, eredis_cluster_pool, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_monitor, brutal_purge, soft_purge, []}
     ]},
-    {<<"0.6.[3-6]">>, [
+    {<<"0\\.6\\.[3-6]">>, [
       {load_module, eredis_cluster_sup, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_pool, brutal_purge, soft_purge, []},
+      {load_module, eredis_cluster_monitor, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []}
     ]},
     {"0.6.7", [
       {load_module, eredis_cluster_sup, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_pool, brutal_purge, soft_purge, []},
+      {load_module, eredis_cluster_monitor, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster, brutal_purge, soft_purge, []}
     ]},
-    {<<"0.7.[0-3]">>, [
+    {<<"0\\.7\\.[0-3]">>, [
       {load_module, eredis_cluster_pool, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_cluster_monitor, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []}
     ]},
     {<<".*">>, [

--- a/src/eredis_cluster.appup.src
+++ b/src/eredis_cluster.appup.src
@@ -1,5 +1,5 @@
 %% -*- mode: erlang -*-
-{"0.7.1",
+{"0.7.4",
   [
     {"0.5.11", [
       {load_module, eredis_cluster_sup, brutal_purge, soft_purge, []},
@@ -21,7 +21,11 @@
     ]},
     {"0.6.7", [
       {load_module, eredis_cluster_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster, brutal_purge, soft_purge, []}
+    ]},
+    {<<"0.7.[0-3]">>, [
+      {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []}
     ]},
     {<<".*">>, [
     ]}
@@ -47,7 +51,11 @@
     ]},
     {"0.6.7", [
       {load_module, eredis_cluster_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster, brutal_purge, soft_purge, []}
+    ]},
+    {<<"0.7.[0-3]">>, [
+      {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []}
     ]},
     {<<".*">>, [
     ]}

--- a/src/eredis_cluster.appup.src
+++ b/src/eredis_cluster.appup.src
@@ -11,20 +11,25 @@
     {"0.6.2", [
       {load_module, eredis_cluster_sup, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster, brutal_purge, soft_purge, []},
+      {load_module, eredis_cluster_pool, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_monitor, brutal_purge, soft_purge, []}
     ]},
     {<<"0.6.[3-6]">>, [
       {load_module, eredis_cluster_sup, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster, brutal_purge, soft_purge, []},
+      {load_module, eredis_cluster_pool, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []}
     ]},
     {"0.6.7", [
       {load_module, eredis_cluster_sup, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []},
+      {load_module, eredis_cluster_pool, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster, brutal_purge, soft_purge, []}
     ]},
     {<<"0.7.[0-3]">>, [
+      {load_module, eredis_cluster_pool, brutal_purge, soft_purge, []},
+      {load_module, eredis_cluster_sup, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []}
     ]},
     {<<".*">>, [
@@ -42,19 +47,24 @@
       {load_module, eredis_cluster_sup, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []},
+      {load_module, eredis_cluster_pool, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_monitor, brutal_purge, soft_purge, []}
     ]},
     {<<"0.6.[3-6]">>, [
       {load_module, eredis_cluster_sup, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster, brutal_purge, soft_purge, []},
+      {load_module, eredis_cluster_pool, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []}
     ]},
     {"0.6.7", [
       {load_module, eredis_cluster_sup, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []},
+      {load_module, eredis_cluster_pool, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster, brutal_purge, soft_purge, []}
     ]},
     {<<"0.7.[0-3]">>, [
+      {load_module, eredis_cluster_pool, brutal_purge, soft_purge, []},
+      {load_module, eredis_cluster_sup, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []}
     ]},
     {<<".*">>, [

--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -15,6 +15,7 @@
 -export([handle_info/2]).
 -export([terminate/2]).
 -export([code_change/3]).
+-export([format_status/2]).
 
 %% Type definition.
 -include("eredis_cluster.hrl").
@@ -251,9 +252,14 @@ terminate(_Reason, #state{slots_maps = Slots}) ->
     [eredis_cluster_pool:stop(SlotsMap#slots_map.node#node.pool) ||
         SlotsMap <- SlotsMapList, SlotsMap#slots_map.node =/= undefined],
     ok.
-% Down
+
 code_change(_, State, _Extra) ->
     {ok, State}.
+
+format_status(_Opt, [_PDict, #state{} = State]) ->
+    [{data, [{"State", State#state{password = "******"}}]}];
+format_status(_Opt, [_PDict, State]) ->
+    [{data, [{"State", State}]}].
 
 name(Name) ->
     list_to_atom("monitor_" ++ atom_to_list(Name)).

--- a/src/eredis_cluster_pool_worker.erl
+++ b/src/eredis_cluster_pool_worker.erl
@@ -13,6 +13,7 @@
 -export([handle_info/2]).
 -export([terminate/2]).
 -export([code_change/3]).
+-export([format_status/2]).
 
 -record(state, {conn, host, port, database, password}).
 
@@ -88,6 +89,11 @@ terminate(_Reason, #state{conn=Conn}) ->
 
 code_change(_, State, _Extra) ->
     {ok, State}.
+
+format_status(_Opt, [_PDict, #state{} = State]) ->
+    [{data, [{"State", State#state{password = "******"}}]}];
+format_status(_Opt, [_PDict, State]) ->
+    [{data, [{"State", State}]}].
 
 safe_query(Func, Conn, Commands) ->
     try eredis:Func(Conn, Commands)

--- a/src/eredis_cluster_pool_worker.erl
+++ b/src/eredis_cluster_pool_worker.erl
@@ -16,7 +16,7 @@
 
 -record(state, {conn, host, port, database, password}).
 
--define(RECONNECT_TIME, 100).
+-define(RECONNECT_TIME, 10000).
 
 is_connected(Pid) ->
     gen_server:call(Pid, is_connected).
@@ -32,8 +32,8 @@ init(Args) ->
     Options = proplists:get_value(options, Args, []),
     erlang:put(options, Options),
     process_flag(trap_exit, true),
-    Conn = start_connection(Hostname, Port, DataBase, Password, Options),
-    {ok, #state{conn = Conn,
+    erlang:send(self(), reconnect),
+    {ok, #state{conn = undefined,
                 host = Hostname,
                 port = Port,
                 database = DataBase,
@@ -46,9 +46,9 @@ handle_call({'query', _}, _From, #state{conn = undefined} = State) ->
     {reply, {error, no_connection}, State};
 handle_call({'query', [[X|_]|_] = Commands}, _From, #state{conn = Conn} = State)
     when is_list(X); is_binary(X) ->
-    {reply, eredis:qp(Conn, Commands), State};
+    {reply, safe_query(qp, Conn, Commands), State};
 handle_call({'query', Command}, _From, #state{conn = Conn} = State) ->
-    {reply, eredis:q(Conn, Command), State};
+    {reply, safe_query(q, Conn, Command), State};
 handle_call(is_connected, _From, #state{conn = Conn}= State) ->
     {reply, Conn =/= undefined andalso is_process_alive(Conn), State};
 handle_call(_Request, _From, State) ->
@@ -68,7 +68,8 @@ handle_info(reconnect, #state{host = Hostname,
     Conn = start_connection(Hostname, Port, DataBase, Password, Options),
     {noreply, State#state{conn = Conn}};
 
-handle_info({'EXIT', Pid, _Reason}, #state{conn = Pid} = State) ->
+handle_info({'EXIT', Pid, _Reason}, #state{conn = Pid0} = State)
+        when Pid0 =:= Pid; Pid0 =:= undefined ->
     erlang:send_after(?RECONNECT_TIME, self(), reconnect),
     {noreply, State#state{conn = undefined}};
 
@@ -84,7 +85,15 @@ terminate(_Reason, #state{conn=Conn}) ->
 code_change(_, State, _Extra) ->
     {ok, State}.
 
+safe_query(Func, Conn, Commands) ->
+    try eredis:Func(Conn, Commands)
+    catch
+        exit:{timeout, _} ->
+            {error, timeout}
+    end.
+
 start_connection(Hostname, Port, DataBase, Password, Options) ->
+    %% NOTE: `eredis:start_link/7` may raise exceptions if connect to redis failed.
     case eredis:start_link(Hostname, Port, DataBase, Password, no_reconnect, 5000, Options) of
         {ok,Connection} ->
             Connection;

--- a/src/eredis_cluster_pool_worker.erl
+++ b/src/eredis_cluster_pool_worker.erl
@@ -16,7 +16,7 @@
 
 -record(state, {conn, host, port, database, password}).
 
--define(RECONNECT_TIME, 10000).
+-define(RECONNECT_TIME, 2000).
 
 is_connected(Pid) ->
     gen_server:call(Pid, is_connected).

--- a/src/eredis_cluster_sup.erl
+++ b/src/eredis_cluster_sup.erl
@@ -20,9 +20,9 @@ init([]) ->
             ],
     {ok, {{one_for_one, 1, 5}, Procs}}.
 
-start_child(Name, Params) ->
+start_child(Name, Opts) ->
     ChildSpec = {name(Name),
-                 {eredis_cluster_monitor, start_link, Params},
+                 {eredis_cluster_monitor, start_link, Opts},
                  permanent, 5000, worker, [eredis_cluster_monitor]},
     supervisor:start_child(?MODULE, ChildSpec).
 


### PR DESCRIPTION
- eredis_cluster_pool_worker crashes on query timeout
- There's too many error logs if connect to redis failed, so we enlarge the reconnect interval from 100ms to 10s.
