### PR TITLE
chore: support blessed `format_status/1` callback 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,8 @@ jobs:
         with:
           otp-version: ${{ matrix.otp }}
           rebar3-version: 3
-      - uses: isbang/compose-action@v1.4.1
+      - name: setup redis cluster
+        run: docker compose up -d --wait
       - name: eunit
         run: rebar3 eunit -v -c
       - name: cover report
@@ -27,3 +28,6 @@ jobs:
         with:
           name: cover
           path: _build/test/cover
+      - name: teardown redis cluster
+        if: always()
+        run: docker compose down || true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,3 +45,16 @@ services:
       - 'REDIS_CLUSTER_CREATOR=yes'
     ports:
       - "30006:${REDIS_PORT_NUMBER}"
+    healthcheck:
+      test: |
+        # Convert `cluster info` output into shell variable assignments 
+        eval "$(
+          redis-cli -a "${REDIS_PASSWORD}" --no-auth-warning cluster info | \
+            grep "^cluster" | \
+            sed -r 's/(\w+):(\w+).*/\1=\2/'
+        )"
+        [ "$$cluster_state" = "ok" ]      || { echo "cluster state = $$cluster_state"; exit 1; }
+        [ "$$cluster_size" -gt 1 ]        || { echo "cluster size = $$cluster_size"; exit 2; }
+        [ "$$cluster_known_nodes" -eq 6 ] || { echo "known nodes = $$cluster_known_nodes"; exit 3; }
+      interval: 5s
+      retries: 3

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %% -*- mode: erlang -*-
 {deps, [
-  {eredis, {git, "https://github.com/emqx/eredis", {tag, "1.2.9"}}},
+  {eredis, {git, "https://github.com/emqx/eredis", {tag, "1.2.10"}}},
   {poolboy, {git, "https://github.com/devinus/poolboy.git", {branch, "1.5.1"}}}
 ]}.
 {erl_opts, [warnings_as_errors,

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {deps, [
   {eredis, {git, "https://github.com/emqx/eredis", {tag, "1.2.10"}}},
-  {poolboy, {git, "https://github.com/devinus/poolboy.git", {branch, "1.5.1"}}}
+  {poolboy, {git, "https://github.com/devinus/poolboy.git", {branch, "1.5.2"}}}
 ]}.
 {erl_opts, [warnings_as_errors,
             warn_export_all]}.

--- a/src/eredis_cluster.appup.src
+++ b/src/eredis_cluster.appup.src
@@ -1,5 +1,5 @@
 %% -*- mode: erlang -*-
-{"0.7.4",
+{"0.7.5",
   [
     {"0.5.11", [
       {load_module, eredis_cluster_sup, brutal_purge, soft_purge, []},
@@ -32,6 +32,10 @@
     {<<"0\\.7\\.[0-3]">>, [
       {load_module, eredis_cluster_pool, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_cluster_monitor, brutal_purge, soft_purge, []},
+      {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []}
+    ]},
+    {"0.7.4", [
       {load_module, eredis_cluster_monitor, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []}
     ]},
@@ -70,6 +74,10 @@
     {<<"0\\.7\\.[0-3]">>, [
       {load_module, eredis_cluster_pool, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_sup, brutal_purge, soft_purge, []},
+      {load_module, eredis_cluster_monitor, brutal_purge, soft_purge, []},
+      {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []}
+    ]},
+    {"0.7.4", [
       {load_module, eredis_cluster_monitor, brutal_purge, soft_purge, []},
       {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []}
     ]},

--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -15,6 +15,7 @@
 -export([handle_info/2]).
 -export([terminate/2]).
 -export([code_change/3]).
+-export([format_status/1]).
 -export([format_status/2]).
 
 %% Type definition.
@@ -256,10 +257,19 @@ terminate(_Reason, #state{slots_maps = Slots}) ->
 code_change(_, State, _Extra) ->
     {ok, State}.
 
-format_status(_Opt, [_PDict, #state{} = State]) ->
-    [{data, [{"State", State#state{password = "******"}}]}];
+format_status(Status = #{state := State}) ->
+    Status#{state => censor_state(State)}.
+
+%% TODO
+%% This is deprecated since OTP-25 in favor of `format_status/1`. Remove once
+%% OTP-25 becomes minimum supported OTP version.
 format_status(_Opt, [_PDict, State]) ->
-    [{data, [{"State", State}]}].
+    [{data, [{"State", censor_state(State)}]}].
+
+censor_state(#state{} = State) ->
+    State#state{password = "******"};
+censor_state(State) ->
+    State.
 
 name(Name) ->
     list_to_atom("monitor_" ++ atom_to_list(Name)).

--- a/src/eredis_cluster_pool_worker.erl
+++ b/src/eredis_cluster_pool_worker.erl
@@ -13,6 +13,7 @@
 -export([handle_info/2]).
 -export([terminate/2]).
 -export([code_change/3]).
+-export([format_status/1]).
 -export([format_status/2]).
 
 -record(state, {conn, host, port, database, password}).
@@ -90,11 +91,20 @@ terminate(_Reason, #state{conn=Conn}) ->
 code_change(_, State, _Extra) ->
     {ok, State}.
 
-format_status(_Opt, [_PDict, #state{} = State]) ->
-    [{data, [{"State", State#state{password = "******"}}]}];
-format_status(_Opt, [_PDict, State]) ->
-    [{data, [{"State", State}]}].
+format_status(Status = #{state := State}) ->
+    Status#{state => censor_state(State)}.
 
+%% TODO
+%% This is deprecated since OTP-25 in favor of `format_status/1`. Remove once
+%% OTP-25 becomes minimum supported OTP version.
+format_status(_Opt, [_PDict, State]) ->
+    [{data, [{"State", censor_state(State)}]}].
+
+censor_state(#state{} = State) ->
+    State#state{password = "******"};
+censor_state(State) ->
+    State.
+    
 safe_query(Func, Conn, Commands) ->
     try eredis:Func(Conn, Commands)
     catch

--- a/test/eredis_cluster_tests.erl
+++ b/test/eredis_cluster_tests.erl
@@ -2,9 +2,13 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+%% eredis_cluster wrappers
 -export([transaction/2]).
 -export([update_key/2]).
 -export([update_hash_field/3]).
+
+%% logger handler
+-export([log/2]).
 
 -define(POOL, ?MODULE).
 -define(POOL_OPTS, [
@@ -20,11 +24,11 @@
 
 setup() ->
     {ok, Apps} = application:ensure_all_started(eredis_cluster),
-    {ok, _Pid} = eredis_cluster:start_pool(?POOL, ?POOL_OPTS),
-    Apps.
+    {ok, MonPid} = eredis_cluster:start_pool(?POOL, ?POOL_OPTS),
+    {Apps, MonPid}.
 
-cleanup(Apps) ->
-    ok = eredis_cluster:stop_pool(?POOL),
+cleanup({Apps, _MonPid}) ->
+    _ = catch eredis_cluster:stop_pool(?POOL),
     ok = lists:foreach(fun application:stop/1, lists:reverse(Apps)).
 
 basic_test_() ->
@@ -166,6 +170,48 @@ basic_test_() ->
     }
 }.
 
+censor_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun({_Apps, MonPid}) -> [
+        {"no password in worker state", fun () ->
+            GetStatus = fun(Worker) ->
+                {status,
+                    Worker,
+                    _,
+                    [_, _, _, _, Misc]
+                } = sys:get_status(Worker),
+                [State] = [State || {data, [{"State", State} | _Rest]} <- Misc],
+                ?assertMatch({state, _Conn, _Host, _Port, _DB, "******"}, State)
+            end,
+            eredis_cluster:transaction(?POOL, GetStatus, "bla")
+        end},
+        {"no password in logger report", fun () ->
+            try
+                ok = logger:add_handler(?MODULE, ?MODULE, #{relay_to => self()}),
+                ok = proc_lib:stop(MonPid, Reason = {hush, ?MODULE}, 1000),
+                receive
+                    {log, Message} ->
+                        ?assertMatch(
+                            {report, #{
+                                label := {gen_server, terminate},
+                                reason := Reason,
+                                state := _
+                            }},
+                            Message
+                        ),
+                        {report, #{state := State}} = Message,
+                        ?assertMatch(
+                            [state, _Nodes, _Slots, _Maps, _Vsn, ?MODULE, _DB, "******" | _],
+                            tuple_to_list(State)
+                        )
+                after 1000 ->
+                    error(timeout)
+                end
+            after
+                logger:remove_handler(?MODULE)
+            end
+        end}
+    ] end}.
+
 transaction(Transaction, PoolKey) ->
     eredis_cluster:transaction(?POOL, Transaction, PoolKey).
 
@@ -174,3 +220,8 @@ update_key(Key, UpdateFun) ->
 
 update_hash_field(Key, Field, UpdateFun) ->
     eredis_cluster:update_hash_field(?POOL, Key, Field, UpdateFun).
+
+log(#{msg := Msg}, #{relay_to := Pid}) ->
+    Pid ! {log, Msg};
+log(_, _) ->
+    ok.


### PR DESCRIPTION
Also mention that `format_status/2` callback is deprecated since OTP-25.
Also ensure tests are working and enable CI workflow to run test.

---

[EMQX-8562](https://emqx.atlassian.net/browse/EMQX-8562)