### PR TITLE
Add eredis to application deps

### DIFF
--- a/src/eredis_cluster.app.src
+++ b/src/eredis_cluster.app.src
@@ -7,6 +7,7 @@
     {applications, [
         kernel,
         stdlib,
+        eredis,
         ecpool
     ]},
     {mod, {eredis_cluster, []}},


### PR DESCRIPTION
Otherwise, sometimes emqx may have the following compilation errors
<img width="672" alt="image" src="https://github.com/turtleDeng/eredis_cluster/assets/13825269/643508f3-cbc5-42e6-a8d7-fc968fe2389f">
