### PR TITLE
fix: trigger slot refresh by `qa` call

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,17 +13,11 @@ jobs:
       fail-fast: false
       matrix:
         erlang:
-          - otp: "24"
-            rebar3: "3.20"
-          - otp: "25"
-            rebar3: "3.22"
-          - otp: "26"
-            rebar3: "3.22"
           - otp: "27"
             rebar3: "3.24"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.erlang.otp }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,10 @@ jobs:
         with:
           otp-version: ${{ matrix.erlang.otp }}
           rebar3-version: ${{ matrix.erlang.rebar3 }}
+      - name: pull redis image
+        run: |
+          source .env
+          docker pull public.ecr.aws/docker/library/redis:${REDIS_TAG}
       - name: setup redis cluster
         run: docker compose up -d --wait
       - name: eunit

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ clean:
 eunit:
 	@rm -rf .eunit
 	@mkdir -p .eunit
-	@ERL_FLAGS="-config test.config" $(REBAR) eunit
+	@ERL_FLAGS="-config test.config" $(REBAR) eunit -v
 
 test: eunit
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,14 @@
-version: '3.9'
-
 services:
   redis-node-0: &redis-node
-    image: docker.io/bitnami/redis-cluster:${REDIS_TAG}
+    image: public.ecr.aws/docker/library/redis:${REDIS_TAG}
+    command: redis-server /usr/local/etc/redis/redis.conf --cluster-enabled yes --cluster-config-file nodes.conf --cluster-node-timeout 5000 --appendonly yes --requirepass ${REDIS_PASSWORD} --masterauth ${REDIS_PASSWORD} --port ${REDIS_PORT_NUMBER} --bind 0.0.0.0
     volumes:
       - ./test/config/users.acl:/usr/local/etc/redis/users.acl
-      - ./test/config/overrides.conf:/opt/bitnami/redis/mounted-etc/overrides.conf
+      - ./test/config/overrides.conf:/usr/local/etc/redis/redis.conf
     ports:
       - "30001:${REDIS_PORT_NUMBER}"
     environment:
       - 'REDIS_PASSWORD=${REDIS_PASSWORD}'
-      - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
     networks:
       vpcbr:
         ipv4_address: 10.5.0.11
@@ -48,7 +46,8 @@ services:
         ipv4_address: 10.5.0.15
 
   redis-node-5:
-    image: docker.io/bitnami/redis-cluster:${REDIS_TAG}
+    image: public.ecr.aws/docker/library/redis:${REDIS_TAG}
+    command: redis-server /usr/local/etc/redis/redis.conf --cluster-enabled yes --cluster-config-file nodes.conf --cluster-node-timeout 5000 --appendonly yes --requirepass ${REDIS_PASSWORD} --masterauth ${REDIS_PASSWORD} --port ${REDIS_PORT_NUMBER} --bind 0.0.0.0
     depends_on:
       - redis-node-0
       - redis-node-1
@@ -57,31 +56,52 @@ services:
       - redis-node-4
     environment:
       - 'REDIS_PASSWORD=${REDIS_PASSWORD}'
-      - 'REDISCLI_AUTH=${REDIS_PASSWORD}'
-      - 'REDIS_CLUSTER_REPLICAS=1'
-      - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
-      - 'REDIS_CLUSTER_CREATOR=yes'
     volumes:
       - ./test/config/users.acl:/usr/local/etc/redis/users.acl
-      - ./test/config/overrides.conf:/opt/bitnami/redis/mounted-etc/overrides.conf
+      - ./test/config/overrides.conf:/usr/local/etc/redis/redis.conf
     ports:
       - "30006:${REDIS_PORT_NUMBER}"
     networks:
       vpcbr:
         ipv4_address: 10.5.0.16
     healthcheck:
-      test: |
-        # Convert `cluster info` output into shell variable assignments
-        eval "$(
-          redis-cli -a "${REDIS_PASSWORD}" --no-auth-warning cluster info | \
-            grep "^cluster" | \
-            sed -r 's/(\w+):(\w+).*/\1=\2/'
-        )"
-        [ "$$cluster_state" = "ok" ]      || { echo "cluster state = $$cluster_state"; exit 1; }
-        [ "$$cluster_size" -gt 1 ]        || { echo "cluster size = $$cluster_size"; exit 2; }
-        [ "$$cluster_known_nodes" -eq 6 ] || { echo "known nodes = $$cluster_known_nodes"; exit 3; }
+      test: ["CMD", "sh", "-c", "redis-cli -a ${REDIS_PASSWORD} --no-auth-warning cluster info | grep 'cluster_state:ok' && redis-cli -a ${REDIS_PASSWORD} --no-auth-warning cluster info | grep 'cluster_known_nodes:6'"]
       interval: 5s
       retries: 3
+
+  redis-cluster-init:
+    image: public.ecr.aws/docker/library/redis:${REDIS_TAG}
+    depends_on:
+      - redis-node-0
+      - redis-node-1
+      - redis-node-2
+      - redis-node-3
+      - redis-node-4
+      - redis-node-5
+    command: |
+      sh -c '
+        echo "Waiting for Redis nodes to be ready..."
+        sleep 10
+
+        echo "Creating Redis cluster..."
+        redis-cli --cluster create \
+          10.5.0.11:6379 \
+          10.5.0.12:6379 \
+          10.5.0.13:6379 \
+          10.5.0.14:6379 \
+          10.5.0.15:6379 \
+          10.5.0.16:6379 \
+          --cluster-replicas 1 \
+          --cluster-yes \
+          -a ${REDIS_PASSWORD}
+
+        echo "Cluster initialization completed!"
+      '
+    environment:
+      - 'REDIS_PASSWORD=${REDIS_PASSWORD}'
+    networks:
+      vpcbr:
+        ipv4_address: 10.5.0.20
 
 networks:
   vpcbr:

--- a/src/eredis_cluster.erl
+++ b/src/eredis_cluster.erl
@@ -273,7 +273,7 @@ qa(PoolName, Command, N) ->
     Pools = eredis_cluster_monitor:get_all_pools(PoolName),
     Transaction = fun(Worker) -> qw(Worker, Command) end,
     Results = [eredis_cluster_pool:transaction(Pool, Transaction) || Pool <- Pools],
-    case lists:any(fun(R) -> R =:= {error, no_connection} end, Results) of
+    case lists:member({error, no_connection}, Results) of
         true ->
             %% Trigger slot refresh
             State = eredis_cluster_monitor:get_state(PoolName),

--- a/src/eredis_cluster.erl
+++ b/src/eredis_cluster.erl
@@ -267,9 +267,28 @@ eval(Pool, Script, ScriptHash, Keys, Args) ->
 %% @end
 %% =============================================================================
 qa(PoolName, Command) ->
+    qa(PoolName, Command, 0).
+
+qa(PoolName, Command, N) ->
     Pools = eredis_cluster_monitor:get_all_pools(PoolName),
     Transaction = fun(Worker) -> qw(Worker, Command) end,
-    [eredis_cluster_pool:transaction(Pool, Transaction) || Pool <- Pools].
+    Results = [eredis_cluster_pool:transaction(Pool, Transaction) || Pool <- Pools],
+    case lists:any(fun(R) -> R =:= {error, no_connection} end, Results) of
+        true ->
+            %% Trigger slot refresh
+            State = eredis_cluster_monitor:get_state(PoolName),
+            Version = eredis_cluster_monitor:get_state_version(State),
+            eredis_cluster_monitor:refresh_mapping(PoolName, Version),
+            case Command =:= [<<"PING">>] andalso N < ?REDIS_CLUSTER_REQUEST_TTL of
+                true ->
+                    %% retry if it's PING command
+                    qa(PoolName, Command, N + 1);
+                false ->
+                    Results
+            end;
+        false ->
+            Results
+    end.
 
 %% =============================================================================
 %% @doc Wrapper function to be used for direct call to a pool worker in the

--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -315,7 +315,15 @@ format_status(_Opt, [_PDict, State]) ->
 -endif.
 
 censor_state(#state{} = State) ->
-    State#state{password = "******"};
+    State#state{
+        password = "******",
+        slots = case State#state.slots of
+            undefined -> undefined;
+            Slots when is_tuple(Slots) ->
+                {slots_tuple, size(Slots), "..."};
+            Other -> Other
+        end
+    };
 censor_state(State) ->
     State.
 

--- a/test.config
+++ b/test.config
@@ -7,6 +7,6 @@
         {pool_size, 5},
         {pool_max_overflow, 0},
         {database, 0},
-        {password, ""}
+        {password, "passw0rd"}
     ]
 }].

--- a/test/config/overrides.conf
+++ b/test/config/overrides.conf
@@ -1,1 +1,19 @@
+# Redis cluster configuration
+cluster-enabled yes
+cluster-config-file nodes.conf
+cluster-node-timeout 5000
+appendonly yes
+
+# Authentication
+requirepass passw0rd
+masterauth passw0rd
+
+# ACL file
 aclfile /usr/local/etc/redis/users.acl
+
+# Network
+bind 0.0.0.0
+port 6379
+
+# Disable protected mode for testing
+protected-mode no


### PR DESCRIPTION
Previously all query APIs may trigger slot refresh except for `qa`.
Now `qa` also triggers refresh.
If command is `PING`, `qa` is also retried for up to 2 times after refresh is triggered.
if it's not `PING`, `qa` result is immediately returned without any retry.