### PR TITLE
fix: prevent monitor crash when CLUSTER SLOTS times out

### DIFF
--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -139,17 +139,17 @@ get_cluster_slots([], State, ErrAcc) ->
 get_cluster_slots([Node|T], State, ErrAcc) ->
     case safe_eredis_start_link(Node, State) of
         {ok,Connection} ->
-          case eredis:q(Connection, ["CLUSTER", "SLOTS"]) of
+          case safe_get_cluster_slots(Connection) of
             {error,<<"ERR unknown command 'CLUSTER'">>} ->
                 get_cluster_slots_from_single_node(Node);
             {error,<<"ERR This instance has cluster support disabled">>} ->
                 get_cluster_slots_from_single_node(Node);
             {ok, ClusterInfo} ->
-                eredis:stop(Connection),
+                safe_eredis_stop(Connection),
                 ClusterInfo;
             Err ->
                 logger:error("Failed to get cluster slots from redis node ~p: ~p", [Node, Err]),
-                eredis:stop(Connection),
+                safe_eredis_stop(Connection),
                 get_cluster_slots(T, State, [{Node, cluster_slots_cmd, Err} | ErrAcc])
           end;
         Err ->
@@ -221,6 +221,19 @@ safe_eredis_start_link(#node{address = Host, port = Port},
         Options0 -> Options0
     end,
     eredis:start_link(Host, Port, DataBase, Password, no_reconnect, 5000, Options).
+
+safe_get_cluster_slots(Connection) ->
+    try eredis:q(Connection, ["CLUSTER", "SLOTS"])
+    catch
+        exit:Reason ->
+            {error, {cluster_slots_exit, Reason}}
+    end.
+
+safe_eredis_stop(Connection) ->
+    try eredis:stop(Connection)
+    catch
+        _:_ -> ok
+    end.
 
 -spec create_slots_cache([#slots_map{}]) -> [integer()].
 create_slots_cache(SlotsMaps) ->

--- a/test/eredis_cluster_tests.erl
+++ b/test/eredis_cluster_tests.erl
@@ -11,6 +11,7 @@
 -export([log/2]).
 
 -define(POOL, ?MODULE).
+-define(MONITOR_TIMEOUT_POOL, monitor_timeout_pool).
 -define(SERVERS, "127.0.0.1:30001,127.0.0.1:30002").
 -define(POOL_OPTS, [
     {servers, format_redis_servers(os:getenv("REDIS_NODE_LIST", ?SERVERS))},
@@ -198,6 +199,45 @@ rainy_day_test_() ->
                     ?assert(length(InitNodes) > 0)
                 end}
         ]
+    }.
+
+monitor_reload_slots_timeout_test_() ->
+    {"monitor survives CLUSTER SLOTS timeout",
+        {timeout, 10, fun() ->
+            meck:new(eredis, [non_strict]),
+            meck:new(eredis_cluster_pool, [non_strict]),
+            try
+                meck:expect(eredis, start_link, fun(_, _, _, _, _, _, _) -> {ok, conn} end),
+                meck:expect(eredis, q, fun(conn, ["CLUSTER", "SLOTS"]) ->
+                    {ok, [[<<"0">>, <<"16383">>, [<<"127.0.0.1">>, <<"6379">>]]]}
+                end),
+                meck:expect(eredis, stop, fun(conn) -> ok end),
+                meck:expect(eredis_cluster_pool, create, fun(_, _, _, _, _, _, _) -> {ok, fake_pool} end),
+                meck:expect(eredis_cluster_pool, stop, fun(_) -> ok end),
+
+                {ok, MonPid} = eredis_cluster_monitor:start_link(?MONITOR_TIMEOUT_POOL, [
+                    {servers, [{"127.0.0.1", 6379}]}
+                ]),
+                ?assert(is_process_alive(MonPid)),
+
+                Version = eredis_cluster_monitor:get_state_version(
+                    eredis_cluster_monitor:get_state(?MONITOR_TIMEOUT_POOL)
+                ),
+
+                meck:expect(eredis, q, fun(conn, ["CLUSTER", "SLOTS"]) ->
+                    exit(timeout);
+                (_, _) ->
+                    {error, no_connection}
+                end),
+
+                Result = catch eredis_cluster_monitor:refresh_mapping(?MONITOR_TIMEOUT_POOL, Version),
+                ?assertNotMatch({'EXIT', _}, Result),
+                ?assert(is_process_alive(MonPid))
+            after
+                catch meck:unload(eredis),
+                catch meck:unload(eredis_cluster_pool)
+            end
+        end}
     }.
 
 censor_test_() ->


### PR DESCRIPTION
## Summary
- catch `exit` from `eredis:q(Connection, ["CLUSTER", "SLOTS"])` in monitor refresh path
- convert exit to normal error tuple so `gen_server` does not crash
- use safe stop wrapper for connection cleanup in this path
- add regression eunit case for refresh timeout behavior

## Verification
- `/home/moo/Worksapce/emqx-enterprise/rebar3 as test eunit -g eredis_cluster_tests:monitor_reload_slots_timeout_test_ -v`