### PR TITLE
fix: prevent monitor crash when CLUSTER SLOTS times out

### DIFF
--- a/src/eredis_cluster.appup.src
+++ b/src/eredis_cluster.appup.src
@@ -1,5 +1,5 @@
 %% -*- mode: erlang -*-
-{"0.7.8",
+{"0.7.9",
   [
     {"0.5.11", [
       {load_module, eredis_cluster_sup, brutal_purge, soft_purge, []},
@@ -54,6 +54,10 @@
     ]},
     {"0.7.7", [
       {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []},
+      {load_module, eredis_cluster_monitor, brutal_purge, soft_purge, []},
+      {apply,{eredis_cluster_monitor,cache_states,[]}}
+    ]},
+    {"0.7.8", [
       {load_module, eredis_cluster_monitor, brutal_purge, soft_purge, []},
       {apply,{eredis_cluster_monitor,cache_states,[]}}
     ]},
@@ -107,6 +111,9 @@
     ]},
     {"0.7.7", [
       {load_module, eredis_cluster_pool_worker, brutal_purge, soft_purge, []},
+      {load_module, eredis_cluster_monitor, brutal_purge, soft_purge, []}
+    ]},
+    {"0.7.8", [
       {load_module, eredis_cluster_monitor, brutal_purge, soft_purge, []}
     ]},
     {<<".*">>, [

--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -141,10 +141,10 @@ get_cluster_slots([Node|T], State, ErrAcc) ->
         {ok,Connection} ->
           case safe_get_cluster_slots(Connection) of
             {error,<<"ERR unknown command 'CLUSTER'">>} ->
-                eredis:stop(Connection),
+                safe_eredis_stop(Connection),
                 get_cluster_slots_from_single_node(Node);
             {error,<<"ERR This instance has cluster support disabled">>} ->
-                eredis:stop(Connection),
+                safe_eredis_stop(Connection),
                 get_cluster_slots_from_single_node(Node);
             {ok, ClusterInfo} ->
                 safe_eredis_stop(Connection),

--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -139,7 +139,7 @@ get_cluster_slots([], State, ErrAcc) ->
 get_cluster_slots([Node|T], State, ErrAcc) ->
     case safe_eredis_start_link(Node, State) of
         {ok,Connection} ->
-          case eredis:q(Connection, ["CLUSTER", "SLOTS"]) of
+          case safe_get_cluster_slots(Connection) of
             {error,<<"ERR unknown command 'CLUSTER'">>} ->
                 eredis:stop(Connection),
                 get_cluster_slots_from_single_node(Node);
@@ -147,11 +147,11 @@ get_cluster_slots([Node|T], State, ErrAcc) ->
                 eredis:stop(Connection),
                 get_cluster_slots_from_single_node(Node);
             {ok, ClusterInfo} ->
-                eredis:stop(Connection),
+                safe_eredis_stop(Connection),
                 ClusterInfo;
             Err ->
                 logger:error("Failed to get cluster slots from redis node ~p: ~p", [Node, Err]),
-                eredis:stop(Connection),
+                safe_eredis_stop(Connection),
                 get_cluster_slots(T, State, [{Node, cluster_slots_cmd, Err} | ErrAcc])
           end;
         Err ->
@@ -223,6 +223,19 @@ safe_eredis_start_link(#node{address = Host, port = Port},
         Options0 -> Options0
     end,
     eredis:start_link(Host, Port, DataBase, Password, no_reconnect, 5000, Options).
+
+safe_get_cluster_slots(Connection) ->
+    try eredis:q(Connection, ["CLUSTER", "SLOTS"])
+    catch
+        exit:Reason ->
+            {error, {cluster_slots_exit, Reason}}
+    end.
+
+safe_eredis_stop(Connection) ->
+    try eredis:stop(Connection)
+    catch
+        _:_ -> ok
+    end.
 
 -spec create_slots_cache([#slots_map{}]) -> [integer()].
 create_slots_cache(SlotsMaps) ->

--- a/test/eredis_cluster_tests.erl
+++ b/test/eredis_cluster_tests.erl
@@ -11,6 +11,7 @@
 -export([log/2]).
 
 -define(POOL, ?MODULE).
+-define(MONITOR_TIMEOUT_POOL, monitor_timeout_pool).
 -define(SERVERS, "127.0.0.1:30001,127.0.0.1:30002").
 -define(POOL_OPTS, [
     {servers, format_redis_servers(os:getenv("REDIS_NODE_LIST", ?SERVERS))},
@@ -198,6 +199,45 @@ rainy_day_test_() ->
                     ?assert(length(InitNodes) > 0)
                 end}
         ]
+    }.
+
+monitor_reload_slots_timeout_test_() ->
+    {"monitor survives CLUSTER SLOTS timeout",
+        {timeout, 10, fun() ->
+            meck:new(eredis, [non_strict]),
+            meck:new(eredis_cluster_pool, [non_strict]),
+            try
+                meck:expect(eredis, start_link, fun(_, _, _, _, _, _, _) -> {ok, conn} end),
+                meck:expect(eredis, q, fun(conn, ["CLUSTER", "SLOTS"]) ->
+                    {ok, [[<<"0">>, <<"16383">>, [<<"127.0.0.1">>, <<"6379">>]]]}
+                end),
+                meck:expect(eredis, stop, fun(conn) -> ok end),
+                meck:expect(eredis_cluster_pool, create, fun(_, _, _, _, _, _, _) -> {ok, fake_pool} end),
+                meck:expect(eredis_cluster_pool, stop, fun(_) -> ok end),
+
+                {ok, MonPid} = eredis_cluster_monitor:start_link(?MONITOR_TIMEOUT_POOL, [
+                    {servers, [{"127.0.0.1", 6379}]}
+                ]),
+                ?assert(is_process_alive(MonPid)),
+
+                Version = eredis_cluster_monitor:get_state_version(
+                    eredis_cluster_monitor:get_state(?MONITOR_TIMEOUT_POOL)
+                ),
+
+                meck:expect(eredis, q, fun(conn, ["CLUSTER", "SLOTS"]) ->
+                    exit(timeout);
+                (_, _) ->
+                    {error, no_connection}
+                end),
+
+                Result = catch eredis_cluster_monitor:refresh_mapping(?MONITOR_TIMEOUT_POOL, Version),
+                ?assertNotMatch({'EXIT', _}, Result),
+                ?assert(is_process_alive(MonPid))
+            after
+                catch meck:unload(eredis),
+                catch meck:unload(eredis_cluster_pool)
+            end
+        end}
     }.
 
 censor_test_() ->

--- a/test/eredis_cluster_tests.erl
+++ b/test/eredis_cluster_tests.erl
@@ -232,7 +232,8 @@ monitor_reload_slots_timeout_test_() ->
 
                 Result = catch eredis_cluster_monitor:refresh_mapping(?MONITOR_TIMEOUT_POOL, Version),
                 ?assertNotMatch({'EXIT', _}, Result),
-                ?assert(is_process_alive(MonPid))
+                ?assert(is_process_alive(MonPid)),
+                ok = gen_server:stop(MonPid, normal, 5000)
             after
                 catch meck:unload(eredis),
                 catch meck:unload(eredis_cluster_pool)


### PR DESCRIPTION
## Background
This PR addresses a Redis Cluster refresh-timeout crash in `eredis_cluster` monitor process on the `branch-0.7.x` line.

## Problems Fixed
1. **Monitor crash during slot refresh timeout**
   - `eredis_cluster_monitor:get_cluster_slots/3` called `eredis:q(Connection, ["CLUSTER", "SLOTS"])` directly in a `gen_server` call path.
   - When `eredis:q/2` exits on timeout, the exception could bubble up and terminate the monitor process.

2. **Potential unsafe connection stop in fallback branches**
   - In some branches (`unknown command` / `cluster disabled`), stop used plain `eredis:stop/1`.
   - This PR unifies those branches to `safe_eredis_stop/1`.

3. **Regression test cleanup instability**
   - The new timeout regression test unloaded meck before monitor shutdown, producing noisy test-time `noproc` termination reports.
   - This PR stops monitor explicitly before unload.

## Typical Error Logs Covered
These are the key log patterns related to this issue:

```erlang
Failed to get cluster slots from redis node ...: {error,{cluster_slots_exit,timeout}}
Failed to get cluster slots: {<<"ERR all nodes are down">>, ...}
```

Before this fix, timeout could additionally lead to monitor termination logs (for example `Generic server monitor_* terminating` due to refresh path exceptions).

## Changes
- `src/eredis_cluster_monitor.erl`
  - Add `safe_get_cluster_slots/1` to catch `exit` from `eredis:q/2` and convert it into normal `{error, ...}` flow.
  - Use `safe_eredis_stop/1` consistently in all `CLUSTER SLOTS` branches.
- `test/eredis_cluster_tests.erl`
  - Add/keep timeout regression case and stop monitor cleanly in test teardown path.
- `src/eredis_cluster.appup.src`
  - Bump appup target to `0.7.9`.
  - Add upgrade/downgrade instructions for `0.7.8`.

## Verification
- `/home/moo/Worksapce/emqx-enterprise/rebar3 as test eunit -g eredis_cluster_tests:monitor_reload_slots_timeout_test_ -v`